### PR TITLE
fix: add eku to ek deps in downstream ci hpc config

### DIFF
--- a/.github/ci-hpc-config.yml
+++ b/.github/ci-hpc-config.yml
@@ -13,6 +13,7 @@ build:
   python_dependencies:
   - ecmwf/eccodes-python@develop
   - ecmwf/pyodc@develop
+  - ecmwf/earthkit-utils@develop
   env:
   - ECCODES_SAMPLES_PATH=$ECCODES_DIR/share/eccodes/samples
   - ECCODES_DEFINITION_PATH=$ECCODES_DIR/share/eccodes/definitions

--- a/.github/ci-hpc-config.yml
+++ b/.github/ci-hpc-config.yml
@@ -14,6 +14,9 @@ build:
   - ecmwf/eccodes-python@develop
   - ecmwf/pyodc@develop
   - ecmwf/earthkit-utils@develop
+  - ecmwf/earthkit-hydro@develop
+  - ecmwf/earthkit-data@develop
+  - ecmwf/earthkit-meteo@develop
   env:
   - ECCODES_SAMPLES_PATH=$ECCODES_DIR/share/eccodes/samples
   - ECCODES_DEFINITION_PATH=$ECCODES_DIR/share/eccodes/definitions


### PR DESCRIPTION
### Description
Add earthkit-utils develop to downstream ci hpc config. Note/question: should we sync the config between here and ekd? They do not match.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 